### PR TITLE
add get command

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/ryanuber/columnize"
+	"github.com/spf13/cobra"
+)
+
+var (
+	getCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get heartbeat",
+		Run:   getRun,
+		Args:  cobra.ExactArgs(1),
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+}
+
+func getRun(cmd *cobra.Command, args []string) {
+	heartbeat, err := heartbeatClient.Get(context.Background(), args[0])
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+
+	output := []string{}
+
+	if !noHeaders {
+		output = append(output, "NAME | STATUS")
+	}
+
+	output = append(output, fmt.Sprintf("%v | %v", heartbeat.Name, getStatus(heartbeat.Heartbeat)))
+
+	fmt.Println(columnize.SimpleFormat(output))
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/454

This PR adds the `heartbeatctl get` command so we can get status for a single heartbeat. This will be use by during E2E to check whether the heartbeat was created and is active.

Tested and working :heavy_check_mark: 
```
$ heartbeatctl get ginger-yfz3i
NAME            STATUS
ginger-yfz3i  ACTIVE
```